### PR TITLE
Add scraped page archive gem to the scraper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,10 @@
 
 source "https://rubygems.org"
 
-ruby "2.0.0"
+ruby "2.3.1"
 
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
 gem "pry"
 gem "colorize"
 gem "nokogiri"
 gem 'mechanize'
-

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "pry"
 gem "colorize"
 gem "nokogiri"
 gem 'mechanize'
+gem 'scraped_page_archive', git: 'https://github.com/everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive
+  revision: 196d5e39680db1d2873e4fcd586f2b4ff3865640
+  specs:
+    scraped_page_archive (0.4.1)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -10,10 +18,15 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     httpclient (2.6.0.1)
@@ -38,6 +51,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
@@ -45,6 +59,14 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     webrobots (0.1.1)
 
 PLATFORMS
@@ -55,4 +77,11 @@ DEPENDENCIES
   mechanize
   nokogiri
   pry
+  scraped_page_archive!
   scraperwiki!
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.12.5

--- a/scraper.rb
+++ b/scraper.rb
@@ -7,7 +7,7 @@ require 'colorize'
 require 'pry'
 require 'cgi'
 require 'mechanize'
-
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy
@@ -24,7 +24,7 @@ def scrape_list(noko)
   noko.xpath('//table[@class="congresistas"]//tr[td]').each do |tr|
     tds = tr.css('td')
     source = URI.join(url, tds[1].css('a/@href').text).to_s
-    data = { 
+    data = {
       id: CGI.parse(URI.parse(source).query)['id'].first,
       sort_name: tds[1].text.tidy,
       # faction: tds[2].text.tidy,
@@ -41,7 +41,7 @@ end
 
 def scrape_person(url)
   noko = noko_for(url)
-  data = { 
+  data = {
     name: noko.css('.nombres .value').text,
     party: noko.css('.grupo .value').text,
     faction: noko.css('.bancada .value').text,


### PR DESCRIPTION
This PR adds the scraped page archive gem to the scraper and also updates the Ruby version to 2.3.1.
